### PR TITLE
delete api 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:14-alpine
+COPY target/*SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-Xmx400M","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberest
+  namespace: kuberest
+  labels:
+    app: kuberest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kuberest
+  template:
+    metadata:
+      labels:
+        app: kuberest
+    spec:
+      serviceAccount: kuberest-sa
+      serviceAccountName: kuberest-sa
+      containers:
+        - name: kuberest
+          image: yemi0750/kuberest:0.0.1-SNAPSHOT
+          ports:
+            - containerPort: 8080

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: kuberest
+  labels:
+    app: kuberest
+  name: kuberest
+spec:
+  rules:
+  - host: kuberest.cloudzcp.com
+    http:
+      paths:
+      - backend:
+          serviceName: kuberest
+          servicePort: http
+        path: /
+  tls:
+  - hosts:
+    - kuberest.cloudzcp.com
+    secretName: cloudzcp-com-cert
+status:
+  loadBalancer:
+    ingress:
+    - hostname: 

--- a/kubernetes/sa-crb.yaml
+++ b/kubernetes/sa-crb.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuberest-sa
+  namespace: kuberest
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuberest-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kuberest-sa
+  namespace: kuberest

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kuberest
+  name: kuberest
+  labels:
+    app: kuberest
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: kuberest

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
 	</parent>
 	<groupId>com.cloudzcp</groupId>
 	<artifactId>kuberest</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>demo</name>
-	<description>Demo project for Spring Boot</description>
+	<version>0.0.3-SNAPSHOT</version>
+	<name>Ununsed Kubernetes Resource API</name>
+	<description>Unused Kubernetes Resource API</description>
 
 	<properties>
 		<java.version>14</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,32 +49,51 @@
   			<version>4.10.3</version>
 		</dependency>
 
-    	<dependency>
-        	<groupId>io.springfox</groupId>
-        	<artifactId>springfox-boot-starter</artifactId>
-        	<version>3.0.0</version>
-    	</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 
 		<dependency>
     		<groupId>com.googlecode.json-simple</groupId>
     		<artifactId>json-simple</artifactId>
     		<version>1.1</version>
 		</dependency>
+		
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.12</version>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
-	
+
 	<repositories>
-        <repository>
-          	<id>jcenter-snapshots</id>
-          	<name>jcenter</name>
-          	<url>https://jcenter.bintray.com/</url>
-        </repository>
-    </repositories>
+		<repository>
+			<id>jcenter-snapshots</id>
+			<name>jcenter</name>
+			<url>https://jcenter.bintray.com/</url>
+		</repository>
+	</repositories>
 	
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<show>private</show>
+					<nohelp>true</nohelp>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -47,27 +48,28 @@
   			<artifactId>kubernetes-client</artifactId>
   			<version>4.10.3</version>
 		</dependency>
-		
-		<repositories>
-        	<repository>
-          		<id>jcenter-snapshots</id>
-          		<name>jcenter</name>
-          		<url>https://jcenter.bintray.com/</url>
-        	</repository>
-    	</repositories>
 
     	<dependency>
         	<groupId>io.springfox</groupId>
         	<artifactId>springfox-boot-starter</artifactId>
         	<version>3.0.0</version>
     	</dependency>
+
 		<dependency>
     		<groupId>com.googlecode.json-simple</groupId>
     		<artifactId>json-simple</artifactId>
     		<version>1.1</version>
 		</dependency>
 	</dependencies>
-
+	
+	<repositories>
+        <repository>
+          	<id>jcenter-snapshots</id>
+          	<name>jcenter</name>
+          	<url>https://jcenter.bintray.com/</url>
+        </repository>
+    </repositories>
+	
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/ConfigController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/ConfigController.java
@@ -2,9 +2,9 @@ package com.cloudzcp.kuberest.api.core.controller;
 
 import java.io.IOException;
 
+import com.cloudzcp.kuberest.api.core.model.ResponseConfig;
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
-import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,15 +12,28 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * Unused Kubernetes Resource를 조회 및 삭제하는 REST API - Config Controller<br>
+ * Resource 종류는 PersistentVolume, PersistentVolumeClaim<br>
+ * 
+ * Config 변경
+ */
 @RestController
 @RequestMapping("/api/v1/unused")
 public class ConfigController {
     
     @Autowired private UnusedResourceService unusedResourceService;
     
+    /**
+     * 특정 config file로 kubernetes client 생성
+     * 
+     * @param file config file
+     * @return ResponseConfig
+     * @throws IOException IOException
+     */
     @PostMapping(value = "config", consumes = { "multipart/form-data" })
-    public JSONObject setConfig(@RequestPart MultipartFile file) throws IOException {
-        JSONObject result = unusedResourceService.setConfig(file);
+    public ResponseConfig setConfig(@RequestPart MultipartFile file) throws IOException {
+        ResponseConfig result = unusedResourceService.setConfig(file);
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/ConfigController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/ConfigController.java
@@ -1,0 +1,26 @@
+package com.cloudzcp.kuberest.api.core.controller;
+
+import java.io.IOException;
+
+import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/unused")
+public class ConfigController {
+    
+    @Autowired private UnusedResourceService unusedResourceService;
+    
+    @PostMapping(value = "config", consumes = { "multipart/form-data" })
+    public JSONObject setConfig(@RequestPart MultipartFile file) throws IOException {
+        JSONObject result = unusedResourceService.setConfig(file);
+        return result;
+    }
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/ConfigController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/ConfigController.java
@@ -2,10 +2,13 @@ package com.cloudzcp.kuberest.api.core.controller;
 
 import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
+
 import com.cloudzcp.kuberest.api.core.model.ResponseConfig;
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -25,15 +28,28 @@ public class ConfigController {
     @Autowired private UnusedResourceService unusedResourceService;
     
     /**
-     * 특정 config file로 kubernetes client 생성
+     * config file로 kubernetes client 생성
      * 
      * @param file config file
+     * @param request HttpServletRequest
      * @return ResponseConfig
      * @throws IOException IOException
      */
     @PostMapping(value = "config", consumes = { "multipart/form-data" })
-    public ResponseConfig setConfig(@RequestPart MultipartFile file) throws IOException {
-        ResponseConfig result = unusedResourceService.setConfig(file);
+    public ResponseConfig setConfig(@RequestPart MultipartFile file, HttpServletRequest request) throws IOException {
+        ResponseConfig result = unusedResourceService.setConfig(file, request);
+        return result;
+    }
+
+    /**
+     * 현재 session의 client context 반환
+     * 
+     * @param request HttpServletRequest
+     * @return ResponseConfig
+     */
+    @GetMapping(value = "config")
+    public ResponseConfig getConfig(HttpServletRequest request) {
+        ResponseConfig result = unusedResourceService.getConfig(request);
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
@@ -1,0 +1,22 @@
+package com.cloudzcp.kuberest.api.core.controller;
+
+import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class DevController {
+    
+    @Autowired private UnusedResourceService unusedResourceService;
+
+    @GetMapping(value = "unused/pods")
+    public JSONObject getMountedPod() {
+        JSONObject result = unusedResourceService.printPVCMountedByPod();
+        return result;
+    }
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
@@ -1,22 +1,33 @@
 package com.cloudzcp.kuberest.api.core.controller;
 
+import com.cloudzcp.kuberest.api.core.model.ResponseMountedPod;
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
-import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Unused Kubernetes Resource를 조회 및 삭제하는 REST API - Dev Controller<br>
+ * Resource 종류는 PersistentVolume, PersistentVolumeClaim<br>
+ * 
+ * 개발용
+ */
 @RestController
 @RequestMapping("/api/v1/unused")
 public class DevController {
     
     @Autowired private UnusedResourceService unusedResourceService;
 
+    /**
+     * client의 모든 Pod를 검사하여 spec.volume에 mount된 pvc 목록 검출
+     * 
+     * @return ResponseMountedPod
+     */
     @GetMapping(value = "pods")
-    public JSONObject getMountedPod() {
-        JSONObject result = unusedResourceService.printPVCMountedByPod();
+    public ResponseMountedPod getMountedPod() {
+        ResponseMountedPod result = unusedResourceService.printPVCMountedByPod();
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/unused")
 public class DevController {
     
     @Autowired private UnusedResourceService unusedResourceService;
 
-    @GetMapping(value = "unused/pods")
+    @GetMapping(value = "pods")
     public JSONObject getMountedPod() {
         JSONObject result = unusedResourceService.printPVCMountedByPod();
         return result;

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/DevController.java
@@ -1,5 +1,7 @@
 package com.cloudzcp.kuberest.api.core.controller;
 
+import javax.servlet.http.HttpServletRequest;
+
 import com.cloudzcp.kuberest.api.core.model.ResponseMountedPod;
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
@@ -22,12 +24,12 @@ public class DevController {
 
     /**
      * client의 모든 Pod를 검사하여 spec.volume에 mount된 pvc 목록 검출
-     * 
+     * @param request HttpServletRequest
      * @return ResponseMountedPod
      */
     @GetMapping(value = "pods")
-    public ResponseMountedPod getMountedPod() {
-        ResponseMountedPod result = unusedResourceService.printPVCMountedByPod();
+    public ResponseMountedPod getMountedPod(HttpServletRequest request) {
+        ResponseMountedPod result = unusedResourceService.printPVCMountedByPod(request);
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -19,26 +19,26 @@ public class UnusedResourceController {
     @Autowired private UnusedResourceService unusedResourceService;
 
     @GetMapping
-    public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList) {
-        JSONObject result = unusedResourceService.findAll(count, deleteList);
+    public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.findAll(count, deleteList, storageclassname, status, label);
         return result;
     }
 
     @GetMapping(value = "ns/{namespace}")
-    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList) {
-        JSONObject result = unusedResourceService.findAll(namespace, count, deleteList);
+    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.findAll(namespace, count, deleteList, storageclassname, status, label);
         return result;
     }
 
     @GetMapping(value = "pvcs")
-    public JSONObject getUnusedPVCList(@RequestParam(required = false)String deleteList) {
-        JSONObject result = unusedResourceService.findPVCList(deleteList);
+    public JSONObject getUnusedPVCList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.findPVCList(deleteList, storageclassname, status, label);
         return result;
     }
 
     @GetMapping(value = "ns/{namespace}/pvcs")
-    public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList) {
-        JSONObject result = unusedResourceService.findPVCList(namespace, deleteList);
+    public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.findPVCList(namespace, deleteList, storageclassname, status, label);
         return result;
     }
 
@@ -49,8 +49,8 @@ public class UnusedResourceController {
     }
 
     @GetMapping(value = "pvs")
-    public JSONObject getUnusedPVList(@RequestParam(required = false)String deleteList) {
-        JSONObject result = unusedResourceService.findPVList(deleteList);
+    public JSONObject getUnusedPVList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.findPVList(deleteList, storageclassname, status, label);
         return result;
     }
 
@@ -69,6 +69,30 @@ public class UnusedResourceController {
     @DeleteMapping(value = "pvs/{pv_name}")
     public JSONObject deleteUnusedPV(@PathVariable String pv_name){
         JSONObject result = unusedResourceService.deleteUnusedPV(pv_name);
+        return result;
+    }
+
+    @PutMapping
+    public JSONObject putLabelOnUnusedAll(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedAll(type, storageclassname, status, label);
+        return result;
+    }
+
+    @PutMapping(value = "ns/{namespace}/pvcs")
+    public JSONObject putLabelOnUnusedPVCInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label);
+        return result;
+    }
+
+    @PutMapping(value = "pvcs")
+    public JSONObject putLabelOnUnusedPVC(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(type, storageclassname, status, label);
+        return result;
+    }
+    
+    @PutMapping(value = "pvs")
+    public JSONObject putLabelOnUnusedPVList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedPVList(type, storageclassname, status, label);
         return result;
     }
 
@@ -104,6 +128,18 @@ public class UnusedResourceController {
             result = unusedResourceService.deleteUnusedPVC();
         } else {
             result = unusedResourceService.deleteUnusedAllScript("pvc");
+        }
+        return result;
+    }
+
+    @DeleteMapping(value = "ns/{namespace}/pvcs")
+    public JSONObject deleteUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean script) {
+        JSONObject result;
+
+        if (script == null || !script) {
+            result = unusedResourceService.deleteUnusedPVC(namespace);
+        } else {
+            result = unusedResourceService.deleteUnusedAllScript("pvc", namespace);
         }
         return result;
     }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -1,8 +1,14 @@
 package com.cloudzcp.kuberest.api.core.controller;
 
+import com.cloudzcp.kuberest.api.core.model.ResponseAll;
+import com.cloudzcp.kuberest.api.core.model.ResponseAllInNamespace;
+import com.cloudzcp.kuberest.api.core.model.ResponsePV;
+import com.cloudzcp.kuberest.api.core.model.ResponsePVC;
+import com.cloudzcp.kuberest.api.core.model.ResponsePVCList;
+import com.cloudzcp.kuberest.api.core.model.ResponsePVList;
+import com.cloudzcp.kuberest.api.core.model.ResponseResult;
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
-import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,105 +18,229 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/** 
+ * Unused Kubernetes Resource를 조회 및 삭제하는 REST API - Controller <br>
+ * Resource 종류는 PersistentVolume, PersistentVolumeClaim
+ */
 @RestController
 @RequestMapping("/api/v1/unused")
 public class UnusedResourceController {
 
     @Autowired private UnusedResourceService unusedResourceService;
 
+    /**
+     * 전체 Unused Kubernetes Resource 목록 조회<br>
+     * Resource 종류 : PersistentVolume, PersistentVolumeClaim<br>
+     * 4가지 조건으로 일부 조회 가능
+     * 
+     * @param count count 출력 여부
+     * @param deleteList (조건 1) unused-delete-list label의 value (exclude : 삭제 방지 대상 / include : 삭제 대상)
+     * @param storageclassname (조건 2) storageClassname
+     * @param status (조건 3) status.phase
+     * @param label (조건 4) label (key:value / key)
+     * @return ResponseAll
+     */
     @GetMapping
-    public JSONObject getUnusedAll(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.findAll(count, deleteList, storageclassname, status, label);
+    public ResponseAll getUnusedAll(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponseAll result = unusedResourceService.findAll(count, deleteList, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 특정 namespace의 Unused Kubernetes Resource 목록 조회<br>
+     * Resource 종류 : PersistentVolumeClaim<br>
+     * 4가지 조회 조건으로 일부 조회 가능
+     * 
+     * @param namespace namespace
+     * @param count count 출력 여부
+     * @param deleteList (조건 1) unused-delete-list label의 value (exclude : 삭제 방지 대상 / include : 삭제 대상)
+     * @param storageclassname (조건 2) storageClassname
+     * @param status (조건 3) status.phase
+     * @param label (조건 4) label (key:value / key)
+     * @return ResponseAllInNamespace
+     */
     @GetMapping(value = "ns/{namespace}")
-    public JSONObject getUnusedAllInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.findAll(namespace, count, deleteList, storageclassname, status, label);
+    public ResponseAllInNamespace getUnusedAllInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponseAllInNamespace result = unusedResourceService.findAll(namespace, count, deleteList, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 전체 Unused PVC 목록 조회<br>
+     * 4가지 조건으로 일부 조회 가능
+     * 
+     * @param deleteList (조건 1) unused-delete-list label의 value (exclude : 삭제 방지 대상 / include : 삭제 대상)
+     * @param storageclassname (조건 2) storageClassname
+     * @param status (조건 3) status.phase
+     * @param label (조건 4) label (key:value / key)
+     * @return ResponsePVCList
+     */
     @GetMapping(value = "pvcs")
-    public JSONObject getUnusedPVCList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.findPVCList(deleteList, storageclassname, status, label);
+    public ResponsePVCList getUnusedPVCList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponsePVCList result = unusedResourceService.findPVCList(deleteList, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 특정 namespace의 Unused PVC 목록 조회<br>
+     * 4가지 조건으로 일부 조회 가능
+     * 
+     * @param namespace namespace
+     * @param deleteList (조건 1) unused-delete-list label의 value (exclude : 삭제 방지 대상 / include : 삭제 대상)
+     * @param storageclassname (조건 2) storageClassname
+     * @param status (조건 3) status.phase
+     * @param label (조건 4) label (key:value / key)
+     * @return ResponsePVCList
+     */
     @GetMapping(value = "ns/{namespace}/pvcs")
-    public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.findPVCList(namespace, deleteList, storageclassname, status, label);
+    public ResponsePVCList getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponsePVCList result = unusedResourceService.findPVCList(namespace, deleteList, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 전체 Unused PV 목록 조회<br>
+     * 4가지 조건으로 일부 조회 가능
+     * 
+     * @param deleteList (조건 1) unused-delete-list label의 value (exclude : 삭제 방지 대상 / include : 삭제 대상)
+     * @param storageclassname (조건 2) storageClassname
+     * @param status (조건 3) status.phase
+     * @param label (조건 4) label (key:value / key)
+     * @return ResponsePVList
+     */
     @GetMapping(value = "pvs")
-    public JSONObject getUnusedPVList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.findPVList(deleteList, storageclassname, status, label);
+    public ResponsePVList getUnusedPVList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponsePVList result = unusedResourceService.findPVList(deleteList, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 단일 Unused PVC의 상세 정보 조회
+     * 
+     * @param namespace pvc namespace
+     * @param pvc_name pvc name
+     * @return ResponsePVC
+     */
     @GetMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public JSONObject describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
-        JSONObject result = unusedResourceService.findPVC(namespace, pvc_name);
+    public ResponsePVC describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
+        ResponsePVC result = unusedResourceService.findPVC(namespace, pvc_name);
         return result;
     }
 
+    /**
+     * 단일 Unused PV의 상세 정보 조회
+     * 
+     * @param pv_name pv name
+     * @return ResponsePV
+     */
     @GetMapping(value = "pvs/{pv_name}")
-    public JSONObject describeUnusedPV(@PathVariable String pv_name) {
-        JSONObject result = unusedResourceService.findPV(pv_name);
+    public ResponsePV describeUnusedPV(@PathVariable String pv_name) {
+        ResponsePV result = unusedResourceService.findPV(pv_name);
         return result;
     }
     
-    @DeleteMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public JSONObject deleteUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name){
-        JSONObject result = unusedResourceService.deleteUnusedPVC(namespace, pvc_name);
-        return result;
-    }
-
-    @DeleteMapping(value = "pvs/{pv_name}")
-    public JSONObject deleteUnusedPV(@PathVariable String pv_name){
-        JSONObject result = unusedResourceService.deleteUnusedPV(pv_name);
-        return result;
-    }
-
+    /**
+     * 전체 Unused Kubernetes Resource에 label 추가<br>
+     * 3가지 조건으로 Resource 지정 가능
+     * 
+     * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @param storageclassname (조건 1) storageClassname
+     * @param status (조건 2) status.phase
+     * @param label (조건 3) label (key:value / key)
+     * @return ResponseResult
+     */
     @PutMapping
-    public JSONObject putLabelOnUnusedAll(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedAll(type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedAll(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedAll(type, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 전체 Unused PVC에 label 추가<br>
+     * 3가지 조건으로 Resource 지정 가능
+     * 
+     * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @param storageclassname (조건 1) storageClassname
+     * @param status (조건 2) status.phase
+     * @param label (조건 3) label (key:value / key)
+     * @return ResponseResult
+     */
     @PutMapping(value = "pvcs")
-    public JSONObject putLabelOnUnusedPVCList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedPVCList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVCList(type, storageclassname, status, label);
         return result;
     }
     
+    /**
+     * 특정 namespace의 Unused PVC에 label 추가<br>
+     * 3가지 조건으로 Resource 지정 가능
+     * 
+     * @param namespace namespace
+     * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @param storageclassname (조건 1) storageClassname
+     * @param status (조건 2) status.phase
+     * @param label (조건 3) label(key:value / key)
+     * @return ResponseResult
+     */
     @PutMapping(value = "ns/{namespace}/pvcs")
-    public JSONObject putLabelOnUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 전체 Unused PV에 label 추가<br>
+     * 3가지 조건으로 Resource 지정 가능
+     * 
+     * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @param storageclassname (조건 1) storageClassname
+     * @param status (조건 2) status.phase
+     * @param label (조건 3) label(key:value / key)
+     * @return ResponseResult
+     */
     @PutMapping(value = "pvs")
-    public JSONObject putLabelOnUnusedPVList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedPVList(type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedPVList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVList(type, storageclassname, status, label);
         return result;
     }
 
+    /**
+     * 단일 Unused PVC에 label 추가
+     * 
+     * @param namespace pvc namespace
+     * @param pvc_name pvc name
+     * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @return ResponseResult
+     */
     @PutMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public JSONObject putLabelOnUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, @RequestParam(value = "type")String type) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedPVC(namespace, pvc_name, type);
+    public ResponseResult putLabelOnUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, @RequestParam(value = "type")String type) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVC(namespace, pvc_name, type);
         return result;
     }
     
+    /**
+     * 단일 Unused PV에 label 추가
+     * 
+     * @param pv_name pv name
+     * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @return ResponseResult
+     */
     @PutMapping(value = "pvs/{pv_name}")
-    public JSONObject putLabelOnUnusedPV(@PathVariable String pv_name, @RequestParam(value = "type")String type) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedPV(pv_name, type);
+    public ResponseResult putLabelOnUnusedPV(@PathVariable String pv_name, @RequestParam(value = "type")String type) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPV(pv_name, type);
         return result;
     }
 
+    /**
+     * 전체 Unused Kubernetes Resource 삭제<br>
+     * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
+     * 
+     * @param script script 여부
+     * @return ResponseResult
+     */
     @DeleteMapping
-    public JSONObject deleteUnusedAll(@RequestParam(required = false)Boolean script) {
-        JSONObject result;
+    public ResponseResult deleteUnusedAll(@RequestParam(required = false)Boolean script) {
+        ResponseResult result;
 
         if (script == null || !script) {
             result = unusedResourceService.deleteUnusedAll();
@@ -120,9 +250,16 @@ public class UnusedResourceController {
         return result;
     }
 
+    /**
+     * 전체 Unused PVC 삭제<br>
+     * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
+     * 
+     * @param script script 여부
+     * @return ResponseResult
+     */
     @DeleteMapping(value = "pvcs")
-    public JSONObject deleteUnusedPVCList(@RequestParam(required = false)Boolean script) {
-        JSONObject result;
+    public ResponseResult deleteUnusedPVCList(@RequestParam(required = false)Boolean script) {
+        ResponseResult result;
 
         if (script == null || !script) {
             result = unusedResourceService.deleteUnusedPVC();
@@ -132,9 +269,17 @@ public class UnusedResourceController {
         return result;
     }
 
+    /**
+     * 특정 namespace의 Unused PVC 삭제<br>
+     * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
+     * 
+     * @param namespace namespace
+     * @param script script 여부
+     * @return ResponseResult
+     */
     @DeleteMapping(value = "ns/{namespace}/pvcs")
-    public JSONObject deleteUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean script) {
-        JSONObject result;
+    public ResponseResult deleteUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean script) {
+        ResponseResult result;
 
         if (script == null || !script) {
             result = unusedResourceService.deleteUnusedPVC(namespace);
@@ -144,15 +289,47 @@ public class UnusedResourceController {
         return result;
     }
     
+    /**
+     * 전체 Unused PV 삭제<br>
+     * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
+     * 
+     * @param script script 여부
+     * @return ResponseResult
+     */
     @DeleteMapping(value = "pvs")
-    public JSONObject deleteUnusedPVList(@RequestParam(required = false)Boolean script) {
-        JSONObject result;
+    public ResponseResult deleteUnusedPVList(@RequestParam(required = false)Boolean script) {
+        ResponseResult result;
 
         if (script == null || !script) {
             result = unusedResourceService.deleteUnusedPV();
         } else {
             result = unusedResourceService.deleteUnusedAllScript("pv");
         }
+        return result;
+    }
+    
+    /**
+     * 단일 Unused PVC 삭제
+     * 
+     * @param namespace pvc namespace
+     * @param pvc_name pvc name
+     * @return ResponseResult
+     */
+    @DeleteMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
+    public ResponseResult deleteUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name){
+        ResponseResult result = unusedResourceService.deleteUnusedPVC(namespace, pvc_name);
+        return result;
+    }
+
+    /**
+     * 단일 Unused PV 삭제
+     * 
+     * @param pv_name pv name
+     * @return ResponseResult
+     */
+    @DeleteMapping(value = "pvs/{pv_name}")
+    public ResponseResult deleteUnusedPV(@PathVariable String pv_name){
+        ResponseResult result = unusedResourceService.deleteUnusedPV(pv_name);
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -1,0 +1,72 @@
+package com.cloudzcp.kuberest.api.core.controller;
+
+import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
+
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class UnusedResourceController {
+    JSONObject result;
+
+    @Autowired private UnusedResourceService unusedResourceService;
+
+    @GetMapping(value = "unused/count")
+    public JSONObject countUnusedResource() {
+        result = unusedResourceService.countAll(null);
+        return result;
+    }
+
+    @GetMapping(value = "unused/ns/{namespace}/count")
+    public JSONObject countUnusedResourceInNamespace(@PathVariable String namespace) {
+        result = unusedResourceService.countAll(namespace);
+        return result;
+    }
+
+    @GetMapping(value = "unused")
+    public JSONObject getUnusedResourceList() {
+        result = unusedResourceService.findAll(null);
+        return result;
+    }
+
+    @GetMapping(value = "unused/ns/{namespace}")
+    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace) {
+        result = unusedResourceService.findAll(namespace);
+        return result;
+    }
+
+    @GetMapping(value = "unused/pvcs")
+    public JSONObject getUnusedPVCList() {
+        result = unusedResourceService.findPVC(null);
+        return result;
+    }
+
+    @GetMapping(value = "unused/ns/{namespace}/pvcs")
+    public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace) {
+        result = unusedResourceService.findPVC(namespace);
+        return result;
+    }
+
+    @GetMapping(value = "unused/ns/{namespace}/pvcs/{pvc_name}")
+    public JSONObject describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
+        result = unusedResourceService.findPVC(namespace, pvc_name);
+        return result;
+    }
+
+    @GetMapping(value = "unused/pvs")
+    public JSONObject getUnusedPVList() {
+        result = unusedResourceService.findPV();
+        return result;
+    }
+
+    @GetMapping(value = "unused/pvs/{pv_name}")
+    public JSONObject describeUnusedPV(@PathVariable String pv_name) {
+        result = unusedResourceService.findPV(pv_name);
+        return result;
+    }
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -19,13 +19,13 @@ public class UnusedResourceController {
     @Autowired private UnusedResourceService unusedResourceService;
 
     @GetMapping
-    public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+    public JSONObject getUnusedAll(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
         JSONObject result = unusedResourceService.findAll(count, deleteList, storageclassname, status, label);
         return result;
     }
 
     @GetMapping(value = "ns/{namespace}")
-    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+    public JSONObject getUnusedAllInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
         JSONObject result = unusedResourceService.findAll(namespace, count, deleteList, storageclassname, status, label);
         return result;
     }
@@ -42,15 +42,15 @@ public class UnusedResourceController {
         return result;
     }
 
-    @GetMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public JSONObject describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
-        JSONObject result = unusedResourceService.findPVC(namespace, pvc_name);
-        return result;
-    }
-
     @GetMapping(value = "pvs")
     public JSONObject getUnusedPVList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
         JSONObject result = unusedResourceService.findPVList(deleteList, storageclassname, status, label);
+        return result;
+    }
+
+    @GetMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
+    public JSONObject describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
+        JSONObject result = unusedResourceService.findPVC(namespace, pvc_name);
         return result;
     }
 
@@ -78,18 +78,18 @@ public class UnusedResourceController {
         return result;
     }
 
-    @PutMapping(value = "ns/{namespace}/pvcs")
-    public JSONObject putLabelOnUnusedPVCInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label);
-        return result;
-    }
-
     @PutMapping(value = "pvcs")
-    public JSONObject putLabelOnUnusedPVC(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+    public JSONObject putLabelOnUnusedPVCList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
         JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(type, storageclassname, status, label);
         return result;
     }
     
+    @PutMapping(value = "ns/{namespace}/pvcs")
+    public JSONObject putLabelOnUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label);
+        return result;
+    }
+
     @PutMapping(value = "pvs")
     public JSONObject putLabelOnUnusedPVList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
         JSONObject result = unusedResourceService.putLabelOnUnusedPVList(type, storageclassname, status, label);

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -7,64 +7,53 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/unused/")
 public class UnusedResourceController {
     JSONObject result;
 
     @Autowired private UnusedResourceService unusedResourceService;
 
-    @GetMapping(value = "unused/count")
-    public JSONObject countUnusedResource() {
-        result = unusedResourceService.countAll(null);
+    @GetMapping
+    public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count) {
+        result = unusedResourceService.findAll(count);
         return result;
     }
 
-    @GetMapping(value = "unused/ns/{namespace}/count")
-    public JSONObject countUnusedResourceInNamespace(@PathVariable String namespace) {
-        result = unusedResourceService.countAll(namespace);
+    @GetMapping(value = "ns/{namespace}")
+    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count) {
+        result = unusedResourceService.findAll(namespace, count);
         return result;
     }
 
-    @GetMapping(value = "unused")
-    public JSONObject getUnusedResourceList() {
-        result = unusedResourceService.findAll(null);
-        return result;
-    }
-
-    @GetMapping(value = "unused/ns/{namespace}")
-    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace) {
-        result = unusedResourceService.findAll(namespace);
-        return result;
-    }
-
-    @GetMapping(value = "unused/pvcs")
+    @GetMapping(value = "pvcs")
     public JSONObject getUnusedPVCList() {
-        result = unusedResourceService.findPVC(null);
+        result = unusedResourceService.findPVCList();
         return result;
     }
 
-    @GetMapping(value = "unused/ns/{namespace}/pvcs")
+    @GetMapping(value = "ns/{namespace}/pvcs")
     public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace) {
-        result = unusedResourceService.findPVC(namespace);
+        result = unusedResourceService.findPVCList(namespace);
         return result;
     }
 
-    @GetMapping(value = "unused/ns/{namespace}/pvcs/{pvc_name}")
+    @GetMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
     public JSONObject describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
         result = unusedResourceService.findPVC(namespace, pvc_name);
         return result;
     }
 
-    @GetMapping(value = "unused/pvs")
+    @GetMapping(value = "pvs")
     public JSONObject getUnusedPVList() {
-        result = unusedResourceService.findPV();
+        result = unusedResourceService.findPVList();
         return result;
     }
 
-    @GetMapping(value = "unused/pvs/{pv_name}")
+    @GetMapping(value = "pvs/{pv_name}")
     public JSONObject describeUnusedPV(@PathVariable String pv_name) {
         result = unusedResourceService.findPV(pv_name);
         return result;

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -1,5 +1,7 @@
 package com.cloudzcp.kuberest.api.core.controller;
 
+import java.io.IOException;
+
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
 import org.json.simple.JSONObject;
@@ -7,16 +9,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/unused")
 public class UnusedResourceController {
 
     @Autowired private UnusedResourceService unusedResourceService;
+
+    @PostMapping(value = "config", consumes = { "multipart/form-data" })
+    public JSONObject setConfig(@RequestPart MultipartFile file) throws IOException {
+        JSONObject result = unusedResourceService.setConfig(file);
+        return result;
+    }
 
     @GetMapping
     public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/unused/")
+@RequestMapping("/api/v1/unused")
 public class UnusedResourceController {
     JSONObject result;
 

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -1,7 +1,5 @@
 package com.cloudzcp.kuberest.api.core.controller;
 
-import java.io.IOException;
-
 import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
 import org.json.simple.JSONObject;
@@ -9,25 +7,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/unused")
 public class UnusedResourceController {
 
     @Autowired private UnusedResourceService unusedResourceService;
-
-    @PostMapping(value = "config", consumes = { "multipart/form-data" })
-    public JSONObject setConfig(@RequestPart MultipartFile file) throws IOException {
-        JSONObject result = unusedResourceService.setConfig(file);
-        return result;
-    }
 
     @GetMapping
     public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -1,5 +1,7 @@
 package com.cloudzcp.kuberest.api.core.controller;
 
+import javax.servlet.http.HttpServletRequest;
+
 import com.cloudzcp.kuberest.api.core.model.ResponseAll;
 import com.cloudzcp.kuberest.api.core.model.ResponseAllInNamespace;
 import com.cloudzcp.kuberest.api.core.model.ResponsePV;
@@ -38,11 +40,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 2) storageClassname
      * @param status (조건 3) status.phase
      * @param label (조건 4) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponseAll
      */
     @GetMapping
-    public ResponseAll getUnusedAll(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponseAll result = unusedResourceService.findAll(count, deleteList, storageclassname, status, label);
+    public ResponseAll getUnusedAll(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponseAll result = unusedResourceService.findAll(count, deleteList, storageclassname, status, label, request);
         return result;
     }
 
@@ -57,11 +60,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 2) storageClassname
      * @param status (조건 3) status.phase
      * @param label (조건 4) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponseAllInNamespace
      */
     @GetMapping(value = "ns/{namespace}")
-    public ResponseAllInNamespace getUnusedAllInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponseAllInNamespace result = unusedResourceService.findAll(namespace, count, deleteList, storageclassname, status, label);
+    public ResponseAllInNamespace getUnusedAllInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponseAllInNamespace result = unusedResourceService.findAll(namespace, count, deleteList, storageclassname, status, label, request);
         return result;
     }
 
@@ -73,11 +77,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 2) storageClassname
      * @param status (조건 3) status.phase
      * @param label (조건 4) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponsePVCList
      */
     @GetMapping(value = "pvcs")
-    public ResponsePVCList getUnusedPVCList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponsePVCList result = unusedResourceService.findPVCList(deleteList, storageclassname, status, label);
+    public ResponsePVCList getUnusedPVCList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponsePVCList result = unusedResourceService.findPVCList(deleteList, storageclassname, status, label, request);
         return result;
     }
 
@@ -90,11 +95,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 2) storageClassname
      * @param status (조건 3) status.phase
      * @param label (조건 4) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponsePVCList
      */
     @GetMapping(value = "ns/{namespace}/pvcs")
-    public ResponsePVCList getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponsePVCList result = unusedResourceService.findPVCList(namespace, deleteList, storageclassname, status, label);
+    public ResponsePVCList getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponsePVCList result = unusedResourceService.findPVCList(namespace, deleteList, storageclassname, status, label, request);
         return result;
     }
 
@@ -106,11 +112,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 2) storageClassname
      * @param status (조건 3) status.phase
      * @param label (조건 4) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponsePVList
      */
     @GetMapping(value = "pvs")
-    public ResponsePVList getUnusedPVList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponsePVList result = unusedResourceService.findPVList(deleteList, storageclassname, status, label);
+    public ResponsePVList getUnusedPVList(@RequestParam(required = false)String deleteList, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponsePVList result = unusedResourceService.findPVList(deleteList, storageclassname, status, label, request);
         return result;
     }
 
@@ -119,11 +126,12 @@ public class UnusedResourceController {
      * 
      * @param namespace pvc namespace
      * @param pvc_name pvc name
+     * @param request HttpServletRequest
      * @return ResponsePVC
      */
     @GetMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public ResponsePVC describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
-        ResponsePVC result = unusedResourceService.findPVC(namespace, pvc_name);
+    public ResponsePVC describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, HttpServletRequest request) {
+        ResponsePVC result = unusedResourceService.findPVC(namespace, pvc_name, request);
         return result;
     }
 
@@ -131,11 +139,12 @@ public class UnusedResourceController {
      * 단일 Unused PV의 상세 정보 조회
      * 
      * @param pv_name pv name
+     * @param request HttpServletRequest
      * @return ResponsePV
      */
     @GetMapping(value = "pvs/{pv_name}")
-    public ResponsePV describeUnusedPV(@PathVariable String pv_name) {
-        ResponsePV result = unusedResourceService.findPV(pv_name);
+    public ResponsePV describeUnusedPV(@PathVariable String pv_name, HttpServletRequest request) {
+        ResponsePV result = unusedResourceService.findPV(pv_name, request);
         return result;
     }
     
@@ -147,11 +156,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @PutMapping
-    public ResponseResult putLabelOnUnusedAll(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponseResult result = unusedResourceService.putLabelOnUnusedAll(type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedAll(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedAll(type, storageclassname, status, label, request);
         return result;
     }
 
@@ -163,11 +173,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label (key:value / key)
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @PutMapping(value = "pvcs")
-    public ResponseResult putLabelOnUnusedPVCList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponseResult result = unusedResourceService.putLabelOnUnusedPVCList(type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedPVCList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVCList(type, storageclassname, status, label, request);
         return result;
     }
     
@@ -180,11 +191,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label(key:value / key)
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @PutMapping(value = "ns/{namespace}/pvcs")
-    public ResponseResult putLabelOnUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponseResult result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVCList(namespace, type, storageclassname, status, label, request);
         return result;
     }
 
@@ -196,11 +208,12 @@ public class UnusedResourceController {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label(key:value / key)
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @PutMapping(value = "pvs")
-    public ResponseResult putLabelOnUnusedPVList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label) {
-        ResponseResult result = unusedResourceService.putLabelOnUnusedPVList(type, storageclassname, status, label);
+    public ResponseResult putLabelOnUnusedPVList(@RequestParam(value = "type")String type, @RequestParam(required = false)String storageclassname, @RequestParam(required = false)String status, @RequestParam(required = false)String label, HttpServletRequest request) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVList(type, storageclassname, status, label, request);
         return result;
     }
 
@@ -210,11 +223,12 @@ public class UnusedResourceController {
      * @param namespace pvc namespace
      * @param pvc_name pvc name
      * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @PutMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public ResponseResult putLabelOnUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, @RequestParam(value = "type")String type) {
-        ResponseResult result = unusedResourceService.putLabelOnUnusedPVC(namespace, pvc_name, type);
+    public ResponseResult putLabelOnUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, @RequestParam(value = "type")String type, HttpServletRequest request) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPVC(namespace, pvc_name, type, request);
         return result;
     }
     
@@ -223,11 +237,12 @@ public class UnusedResourceController {
      * 
      * @param pv_name pv name
      * @param type unused-delete-list label의 desired value (exclude : 삭제 방지 대상 / include : 삭제 대상 / release : 삭제 지정 해제)
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @PutMapping(value = "pvs/{pv_name}")
-    public ResponseResult putLabelOnUnusedPV(@PathVariable String pv_name, @RequestParam(value = "type")String type) {
-        ResponseResult result = unusedResourceService.putLabelOnUnusedPV(pv_name, type);
+    public ResponseResult putLabelOnUnusedPV(@PathVariable String pv_name, @RequestParam(value = "type")String type, HttpServletRequest request) {
+        ResponseResult result = unusedResourceService.putLabelOnUnusedPV(pv_name, type, request);
         return result;
     }
 
@@ -236,14 +251,15 @@ public class UnusedResourceController {
      * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
      * 
      * @param script script 여부
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @DeleteMapping
-    public ResponseResult deleteUnusedAll(@RequestParam(required = false)Boolean script) {
+    public ResponseResult deleteUnusedAll(@RequestParam(required = false)Boolean script, HttpServletRequest request) {
         ResponseResult result;
 
         if (script == null || !script) {
-            result = unusedResourceService.deleteUnusedAll();
+            result = unusedResourceService.deleteUnusedAll(request);
         } else {
             result = unusedResourceService.deleteUnusedAllScript("pv,pvc");
         }
@@ -255,14 +271,15 @@ public class UnusedResourceController {
      * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
      * 
      * @param script script 여부
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @DeleteMapping(value = "pvcs")
-    public ResponseResult deleteUnusedPVCList(@RequestParam(required = false)Boolean script) {
+    public ResponseResult deleteUnusedPVCList(@RequestParam(required = false)Boolean script, HttpServletRequest request) {
         ResponseResult result;
 
         if (script == null || !script) {
-            result = unusedResourceService.deleteUnusedPVC();
+            result = unusedResourceService.deleteUnusedPVC(request);
         } else {
             result = unusedResourceService.deleteUnusedAllScript("pvc");
         }
@@ -275,14 +292,15 @@ public class UnusedResourceController {
      * 
      * @param namespace namespace
      * @param script script 여부
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @DeleteMapping(value = "ns/{namespace}/pvcs")
-    public ResponseResult deleteUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean script) {
+    public ResponseResult deleteUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean script, HttpServletRequest request) {
         ResponseResult result;
 
         if (script == null || !script) {
-            result = unusedResourceService.deleteUnusedPVC(namespace);
+            result = unusedResourceService.deleteUnusedPVC(namespace, request);
         } else {
             result = unusedResourceService.deleteUnusedAllScript("pvc", namespace);
         }
@@ -294,14 +312,15 @@ public class UnusedResourceController {
      * "unused-delete-list : include" label을 가지는 Resource만을 대상으로 함
      * 
      * @param script script 여부
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @DeleteMapping(value = "pvs")
-    public ResponseResult deleteUnusedPVList(@RequestParam(required = false)Boolean script) {
+    public ResponseResult deleteUnusedPVList(@RequestParam(required = false)Boolean script, HttpServletRequest request) {
         ResponseResult result;
 
         if (script == null || !script) {
-            result = unusedResourceService.deleteUnusedPV();
+            result = unusedResourceService.deleteUnusedPV(request);
         } else {
             result = unusedResourceService.deleteUnusedAllScript("pv");
         }
@@ -313,11 +332,12 @@ public class UnusedResourceController {
      * 
      * @param namespace pvc namespace
      * @param pvc_name pvc name
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @DeleteMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
-    public ResponseResult deleteUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name){
-        ResponseResult result = unusedResourceService.deleteUnusedPVC(namespace, pvc_name);
+    public ResponseResult deleteUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, HttpServletRequest request){
+        ResponseResult result = unusedResourceService.deleteUnusedPVC(namespace, pvc_name, request);
         return result;
     }
 
@@ -325,11 +345,12 @@ public class UnusedResourceController {
      * 단일 Unused PV 삭제
      * 
      * @param pv_name pv name
+     * @param request HttpServletRequest
      * @return ResponseResult
      */
     @DeleteMapping(value = "pvs/{pv_name}")
-    public ResponseResult deleteUnusedPV(@PathVariable String pv_name){
-        ResponseResult result = unusedResourceService.deleteUnusedPV(pv_name);
+    public ResponseResult deleteUnusedPV(@PathVariable String pv_name, HttpServletRequest request){
+        ResponseResult result = unusedResourceService.deleteUnusedPV(pv_name, request);
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/controller/UnusedResourceController.java
@@ -4,8 +4,10 @@ import com.cloudzcp.kuberest.api.core.service.UnusedResourceService;
 
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,49 +15,108 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/unused")
 public class UnusedResourceController {
-    JSONObject result;
 
     @Autowired private UnusedResourceService unusedResourceService;
 
     @GetMapping
-    public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count) {
-        result = unusedResourceService.findAll(count);
+    public JSONObject getUnusedResourceList(@RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList) {
+        JSONObject result = unusedResourceService.findAll(count, deleteList);
         return result;
     }
 
     @GetMapping(value = "ns/{namespace}")
-    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count) {
-        result = unusedResourceService.findAll(namespace, count);
+    public JSONObject getUnusedResourceListInNamespace(@PathVariable String namespace, @RequestParam(required = false)Boolean count, @RequestParam(required = false)String deleteList) {
+        JSONObject result = unusedResourceService.findAll(namespace, count, deleteList);
         return result;
     }
 
     @GetMapping(value = "pvcs")
-    public JSONObject getUnusedPVCList() {
-        result = unusedResourceService.findPVCList();
+    public JSONObject getUnusedPVCList(@RequestParam(required = false)String deleteList) {
+        JSONObject result = unusedResourceService.findPVCList(deleteList);
         return result;
     }
 
     @GetMapping(value = "ns/{namespace}/pvcs")
-    public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace) {
-        result = unusedResourceService.findPVCList(namespace);
+    public JSONObject getUnusedPVCListInNamespace(@PathVariable String namespace, @RequestParam(required = false)String deleteList) {
+        JSONObject result = unusedResourceService.findPVCList(namespace, deleteList);
         return result;
     }
 
     @GetMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
     public JSONObject describeUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name) {
-        result = unusedResourceService.findPVC(namespace, pvc_name);
+        JSONObject result = unusedResourceService.findPVC(namespace, pvc_name);
         return result;
     }
 
     @GetMapping(value = "pvs")
-    public JSONObject getUnusedPVList() {
-        result = unusedResourceService.findPVList();
+    public JSONObject getUnusedPVList(@RequestParam(required = false)String deleteList) {
+        JSONObject result = unusedResourceService.findPVList(deleteList);
         return result;
     }
 
     @GetMapping(value = "pvs/{pv_name}")
     public JSONObject describeUnusedPV(@PathVariable String pv_name) {
-        result = unusedResourceService.findPV(pv_name);
+        JSONObject result = unusedResourceService.findPV(pv_name);
+        return result;
+    }
+    
+    @DeleteMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
+    public JSONObject deleteUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name){
+        JSONObject result = unusedResourceService.deleteUnusedPVC(namespace, pvc_name);
+        return result;
+    }
+
+    @DeleteMapping(value = "pvs/{pv_name}")
+    public JSONObject deleteUnusedPV(@PathVariable String pv_name){
+        JSONObject result = unusedResourceService.deleteUnusedPV(pv_name);
+        return result;
+    }
+
+    @PutMapping(value = "ns/{namespace}/pvcs/{pvc_name}")
+    public JSONObject putLabelOnUnusedPVC(@PathVariable String namespace, @PathVariable String pvc_name, @RequestParam(value = "type")String type) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedPVC(namespace, pvc_name, type);
+        return result;
+    }
+    
+    @PutMapping(value = "pvs/{pv_name}")
+    public JSONObject putLabelOnUnusedPV(@PathVariable String pv_name, @RequestParam(value = "type")String type) {
+        JSONObject result = unusedResourceService.putLabelOnUnusedPV(pv_name, type);
+        return result;
+    }
+
+    @DeleteMapping
+    public JSONObject deleteUnusedAll(@RequestParam(required = false)Boolean script) {
+        JSONObject result;
+
+        if (script == null || !script) {
+            result = unusedResourceService.deleteUnusedAll();
+        } else {
+            result = unusedResourceService.deleteUnusedAllScript("pv,pvc");
+        }
+        return result;
+    }
+
+    @DeleteMapping(value = "pvcs")
+    public JSONObject deleteUnusedPVCList(@RequestParam(required = false)Boolean script) {
+        JSONObject result;
+
+        if (script == null || !script) {
+            result = unusedResourceService.deleteUnusedPVC();
+        } else {
+            result = unusedResourceService.deleteUnusedAllScript("pvc");
+        }
+        return result;
+    }
+    
+    @DeleteMapping(value = "pvs")
+    public JSONObject deleteUnusedPVList(@RequestParam(required = false)Boolean script) {
+        JSONObject result;
+
+        if (script == null || !script) {
+            result = unusedResourceService.deleteUnusedPV();
+        } else {
+            result = unusedResourceService.deleteUnusedAllScript("pv");
+        }
         return result;
     }
 }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/MountedPVC.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/MountedPVC.java
@@ -1,0 +1,18 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * PVC, PVC와 bound된 PV
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class MountedPVC {
+    /** PVC name */
+    String name;
+    /** Bounded PV name */
+    String boundedPV;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/MountedPod.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/MountedPod.java
@@ -1,0 +1,22 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Pod, Pod에 mount된 PVC, PVC와 bound된 PV 목록
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class MountedPod {
+    /** pod name */
+    String name;
+    /** pod namespace */
+    String namespace;
+    /** mounted PVC List */
+    List<MountedPVC> mountedPVC;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseAll.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseAll.java
@@ -1,0 +1,20 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Unused PV, PVC 
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponseAll {
+    /** selfLink */
+    String selfLink;
+    /** PersistentVolume List */
+    UnusedPVList pv;
+    /** PersistentVolumeClaim List */
+    UnusedPVCList pvc;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseAllInNamespace.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseAllInNamespace.java
@@ -1,0 +1,18 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Unused PVC In Namespace
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponseAllInNamespace {
+    /** selfLink */
+    String selfLink;
+    /** PersistentVolume List */
+    UnusedPVCList pvc;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseConfig.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseConfig.java
@@ -1,0 +1,18 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Kubernetes Client의 Context
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponseConfig {
+    /** selfLink */
+    String selfLink;
+    /** context */
+    Object context;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseMountedPod.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseMountedPod.java
@@ -1,0 +1,18 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * MountedPod
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponseMountedPod {
+    /** Pod-mountedPVC-boundedPV List */
+    List<MountedPod> podSpecMountedVolume;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePV.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePV.java
@@ -1,0 +1,20 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 단일 Unused PV
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponsePV {
+    /** selfLink */
+    String selfLink;
+    /** unused type */
+    String unusedType;
+    /** PV */
+    Object PV;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePVC.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePVC.java
@@ -1,0 +1,20 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 단일 Unused PVC
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponsePVC {
+    /** selfLink */
+    String selfLink;
+    /** unused type */
+    String unusedType;
+    /** PVC */
+    Object PVC;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePVCList.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePVCList.java
@@ -1,0 +1,18 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/** 
+ * Unused PVC List
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponsePVCList {
+    /** selfLink */
+    String selfLink;
+    /** PVC List */
+    UnusedPVCList pvc;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePVList.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponsePVList.java
@@ -1,0 +1,18 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Unused PV List
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponsePVList {
+    /** selfLink */
+    String selfLink;
+    /** PV List */
+    UnusedPVList pv;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseResult.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/ResponseResult.java
@@ -1,0 +1,15 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class ResponseResult {
+    /** selfLink */
+    String selfLink;
+    /** result */
+    String result;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPV.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPV.java
@@ -1,0 +1,25 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class UnusedPV {
+    /** name */
+    String name;
+    /** volumeReclaimPolicy */
+    String volumeReclaimPolicy;
+    /** status */
+    String status;
+    /** bound된 pvc name */
+    String boundedPVC;
+    /** storageClassName */
+    String storageClassName;
+    /** 'unused-delete-list' label의 value */
+    String unusedDeleteList;
+    /** unused type */
+    String unusedType;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPVC.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPVC.java
@@ -1,0 +1,25 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class UnusedPVC {
+    /** name */
+    String name;
+    /** namespace */
+    String namespace;
+    /** status */
+    String status;
+    /** bound된 pv name */
+    String boundedPV;
+    /** storageClassName */
+    String storageClassName;
+    /** 'unused-delete-list' label의 value */
+    String unusedDeleteList;
+    /** unused type */
+    String unusedType;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPVCList.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPVCList.java
@@ -1,0 +1,21 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import java.util.HashMap;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Unused PVC list, count
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class UnusedPVCList {
+    /** Unused PVC List */
+    List<UnusedPVC> unusedList;
+    /** Unused PVC Count */
+    HashMap<String, Integer> unusedCount;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPVList.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/model/UnusedPVList.java
@@ -1,0 +1,21 @@
+package com.cloudzcp.kuberest.api.core.model;
+
+import java.util.HashMap;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Unused PV list, count
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class UnusedPVList {
+    /** Unused PV List */
+    List<UnusedPV> unusedList;
+    /** Unused PV Count */
+    HashMap<String, Integer> unusedCount;
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
@@ -7,11 +7,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.fabric8.kubernetes.api.model.PersistentVolume;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
 import io.fabric8.kubernetes.api.model.PersistentVolumeList;
+import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -25,6 +27,20 @@ public class UnusedResourceService {
     private static String apiurl_pvcs = "api/v1/unused/pvcs";
     private static String apiurl_pvs = "api/v1/unused/pvs";
 
+    public JSONObject setConfig(MultipartFile conf) throws IOException {
+
+        JSONObject data = new JSONObject();
+        JSONObject response = new JSONObject();
+    
+        String content = new String(conf.getBytes());
+        Config kubeconfig = Config.fromKubeconfig(content);
+        client = new DefaultKubernetesClient(kubeconfig);
+
+        data.put("result", client.getConfiguration().getContexts());
+        response.put("data", data);
+        return response;
+    }
+    
     public JSONArray findAllPVCMountedByPod(){
 
         JSONArray pod_object_list = new JSONArray();

--- a/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
@@ -21,10 +21,10 @@ public class UnusedResourceService {
 
     private static KubernetesClient client = new DefaultKubernetesClient();
 
-    private static final String apiurl = "api/v1/unused";
-    private static final String apiurl_ns = "api/v1/unused/ns/";
-    private static final String apiurl_pvcs = "api/v1/unused/pvcs";
-    private static final String apiurl_pvs = "api/v1/unused/pvs";
+    private static final String APIURL = "api/v1/unused";
+    private static final String APIURL_NS = "api/v1/unused/ns/";
+    private static final String APIURL_PVCS = "api/v1/unused/pvcs";
+    private static final String APIURL_PVS = "api/v1/unused/pvs";
 
     //thread safe 문제 해결 필요
     public JSONObject setConfig(MultipartFile conf) throws IOException {
@@ -266,7 +266,7 @@ public class UnusedResourceService {
         PersistentVolumeClaimList pvc_list;
         PersistentVolumeList pv_list;
 
-        data.put("selfLink", apiurl);
+        data.put("selfLink", APIURL);
         if (deleteList != null) {
             pvc_list = client.persistentVolumeClaims().inAnyNamespace().withLabel("unused-delete-list", deleteList).list();
             pv_list = client.persistentVolumes().withLabel("unused-delete-list", deleteList).list();
@@ -293,7 +293,7 @@ public class UnusedResourceService {
 
         PersistentVolumeClaimList pvc_list;
 
-        data.put("selfLink", apiurl_ns+namespace);
+        data.put("selfLink", APIURL_NS+namespace);
         if (deleteList != null) {
             pvc_list = client.persistentVolumeClaims().inNamespace(namespace).withLabel("unused-delete-list", deleteList).list();
         } else {
@@ -315,7 +315,7 @@ public class UnusedResourceService {
 
         PersistentVolumeClaimList pvc_list;
 
-        data.put("selfLink", apiurl_pvcs);
+        data.put("selfLink", APIURL_PVCS);
         if (deleteList != null) {
             pvc_list = client.persistentVolumeClaims().inAnyNamespace().withLabel("unused-delete-list", deleteList).list();
         } else {
@@ -336,7 +336,7 @@ public class UnusedResourceService {
 
         PersistentVolumeClaimList pvc_list;
 
-        data.put("selfLink", apiurl_ns+namespace+"/pvcs");
+        data.put("selfLink", APIURL_NS+namespace+"/pvcs");
         if (deleteList != null) {
             pvc_list = client.persistentVolumeClaims().inNamespace(namespace).withLabel("unused-delete-list", deleteList).list();
         } else {
@@ -370,7 +370,7 @@ public class UnusedResourceService {
             data.put("PVC", pvc_object);
         }
 
-        data.put("selfLink", apiurl_ns+namespace+"/pvcs/"+name);
+        data.put("selfLink", APIURL_NS+namespace+"/pvcs/"+name);
         response.put("data", data);
         return response;
     }
@@ -383,7 +383,7 @@ public class UnusedResourceService {
 
         PersistentVolumeList pv_list;
 
-        data.put("selfLink", apiurl_pvs);
+        data.put("selfLink", APIURL_PVS);
         if (deleteList != null) {
             pv_list = client.persistentVolumes().withLabel("unused-delete-list", deleteList).list();
         } else {
@@ -417,7 +417,7 @@ public class UnusedResourceService {
             data.put("PVC", pv_object);
         }
 
-        data.put("selfLink", apiurl_pvs+name);
+        data.put("selfLink", APIURL_PVS+name);
         response.put("data", data);
         return response;
     }
@@ -654,7 +654,7 @@ public class UnusedResourceService {
             result = "bad request / type = [ exclude / include / release ]";
         }
         
-        data.put("selfLink", apiurl_ns+namespace+"/pvcs");
+        data.put("selfLink", APIURL_NS+namespace+"/pvcs");
         data.put("result", result);
         response.put("data", data);
         return response;
@@ -673,7 +673,7 @@ public class UnusedResourceService {
             result = "bad request / type = [ exclude / include / release ]";
         }
         
-        data.put("selfLink", apiurl_pvcs);
+        data.put("selfLink", APIURL_PVCS);
         data.put("result", result);
         response.put("data", data);
         return response;
@@ -692,7 +692,7 @@ public class UnusedResourceService {
             result = "bad request / type = [ exclude / include / release ]";
         }
         
-        data.put("selfLink", apiurl_pvs);
+        data.put("selfLink", APIURL_PVS);
         data.put("result", result);
         response.put("data", data);
         return response;
@@ -754,7 +754,7 @@ public class UnusedResourceService {
             }
         }
         
-        data.put("selfLink", apiurl_ns+namespace+"/pvcs/"+pvc_name);
+        data.put("selfLink", APIURL_NS+namespace+"/pvcs/"+pvc_name);
         data.put("result", result);
         response.put("data", data);
         return response;
@@ -815,7 +815,7 @@ public class UnusedResourceService {
             }
         }
 
-        data.put("selfLink", apiurl_pvs+pv_name);
+        data.put("selfLink", APIURL_PVS+pv_name);
         data.put("result", result);
         response.put("data", data);
         return response;

--- a/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
@@ -129,7 +129,7 @@ public class UnusedResourceService {
      * @param mountedPodList pod spec에 명시된 pvc list
      * @param pvcName pvc name
      * @param pvcNamespace pvc namespace
-     * @return boolean
+     * @return boolean. pvc가 pod spec.volume에 명시된 경우 true
      */
     private boolean isMountedByPod(List<MountedPod> mountedPodList, String pvcName, String pvcNamespace){
 
@@ -152,7 +152,7 @@ public class UnusedResourceService {
      * (검사 기준 2) Pod의 spec에 명시되어 있지 않으면 return true
      * @param mountedPodList pod spec에 명시된 pvc list
      * @param pvc pvc
-     * @return boolean
+     * @return boolean. pvc가 unused인 경우 true
      */
     private boolean isUnusedPVC(List<MountedPod> mountedPodList, PersistentVolumeClaim pvc) {
 
@@ -178,7 +178,7 @@ public class UnusedResourceService {
      * (검사 기준 3) Bound된 PV가 Pod의 spec에 명시되어 있지 않으면 return true
      * @param mountedPodList pod spec에 명시된 pvc list
      * @param pv pv
-     * @return boolean
+     * @return boolean. pv가 unused인 경우 true
      */
     private boolean isUnusedPV(List<MountedPod> mountedPodList, PersistentVolume pv) {
 
@@ -205,7 +205,7 @@ public class UnusedResourceService {
      * PVC가 Unused Resource로 판단된 이유를 반환
      * @param mountedPodList pod spec에 명시된 pvc list
      * @param pvc pvc
-     * @return String
+     * @return String. Unused Type
      */
     private String checkUnusedPVCType(List<MountedPod> mountedPodList, PersistentVolumeClaim pvc) {
 
@@ -227,7 +227,7 @@ public class UnusedResourceService {
      * PV가 Unused Resource로 판단된 이유를 반환
      * @param mountedPodList pod spec에 명시된 pvc list
      * @param pv pv
-     * @return String
+     * @return String. Unused Type
      */
     private String checkUnusedPVType(List<MountedPod> mountedPodList, PersistentVolume pv) {
 
@@ -578,7 +578,7 @@ public class UnusedResourceService {
     /**
      * PVC의 unused-delete-list label 존재 여부와 value 검사
      * @param pvc pvc
-     * @return String
+     * @return String. pvc의 'unused-delete-list' label의 value
      */
     private String checkUnusedPVCDeleteListLabel(PersistentVolumeClaim pvc) {
 
@@ -593,7 +593,7 @@ public class UnusedResourceService {
     /**
      * PV의 unused-delete-list label 존재 여부와 value 검사
      * @param pv pv
-     * @return String
+     * @return String. pv의 'unused-delete-list' label의 value
      */
     private String checkUnusedPVDeleteListLabel(PersistentVolume pv) {
 
@@ -611,7 +611,7 @@ public class UnusedResourceService {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label (key:value / key)
-     * @return boolean
+     * @return boolean. pvc가 조건 1~3을 만족하는 경우 true
      */
     private boolean checkPVCFields(PersistentVolumeClaim pvc, String storageclassname, String status, String label) {
 
@@ -649,7 +649,7 @@ public class UnusedResourceService {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label (key:value / key)
-     * @return boolean
+     * @return boolean. pv가 조건 1~3을 만족하는 경우 true
      */
     private boolean checkPVFields(PersistentVolume pv, String storageclassname, String status, String label) {
 
@@ -685,7 +685,7 @@ public class UnusedResourceService {
      * PVC의 'unused-delete-list' label의 value를 desired value로 변경하고, 변경 여부 반환
      * @param pvc pvc
      * @param type 'unused-delete-list' label의 desired value
-     * @return boolean
+     * @return boolean. pvc의 'unused-delete-list' label의 value가 desired value로 변경되면 true
      * @see #checkUnusedPVCDeleteListLabel(PersistentVolumeClaim)
      */
     private boolean checkPVCLabelEdited(PersistentVolumeClaim pvc, String type) {
@@ -722,7 +722,7 @@ public class UnusedResourceService {
      * PV의 'unused-delete-list' label의 value를 desired value로 변경하고, 변경 여부 반환
      * @param pv pv
      * @param type 'unused-delete-list' label의 desired value
-     * @return boolean
+     * @return boolean. pv의 'unused-delete-list' label의 value가 desired value로 변경되면 true
      * @see #checkUnusedPVDeleteListLabel(PersistentVolume)
      */
     private boolean checkPVLabelEdited(PersistentVolume pv, String type) {
@@ -762,7 +762,7 @@ public class UnusedResourceService {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label (key:value / key)
-     * @return String
+     * @return String. pvcList 각 pvc의 'unused-delete-list' label의 value 변경 결과
      * @see #isUnusedPVC(List, PersistentVolumeClaim)
      * @see #checkPVCFields(PersistentVolumeClaim, String, String, String)
      * @see #checkPVCLabelEdited(PersistentVolumeClaim, String)
@@ -789,7 +789,7 @@ public class UnusedResourceService {
      * @param storageclassname (조건 1) storageClassname
      * @param status (조건 2) status.phase
      * @param label (조건 3) label (key:value / key)
-     * @return String
+     * @return String. pvList 각 pv의 'unused-delete-list' label의 value 변경 결과
      * @see #isUnusedPV(List, PersistentVolume)
      * @see #checkPVFields(PersistentVolume, String, String, String)
      * @see #checkPVLabelEdited(PersistentVolume, String)
@@ -1088,6 +1088,35 @@ public class UnusedResourceService {
     }
 
     /**
+     * 단일 PVC를 삭제
+     * @param pvc pvc
+     * @return boolean. 삭제 성공 시 return true
+     */
+    private boolean isDeleted(PersistentVolumeClaim pvc) {
+        String pvcName = pvc.getMetadata().getName();
+        String pvcNamespace = pvc.getMetadata().getNamespace();
+
+        if (client.persistentVolumeClaims().inNamespace(pvcNamespace).withName(pvcName).delete()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 단일 PV를 삭제
+     * @param pv pv
+     * @return boolean. 삭제 성공 시 true
+     */
+    private boolean isDeleted(PersistentVolume pv) {
+        String pvName = pv.getMetadata().getName();
+
+        if (client.persistentVolumes().withName(pvName).delete()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * client가 조회할 수 있는 모든 Resource 중 'unused-delete-list : include' label 가지는 Unused Resource 삭제<br>
      * deleteUnusedPVC(), deleteUnusedPV()
      * @return ResponseResult
@@ -1109,24 +1138,19 @@ public class UnusedResourceService {
     /**
      * client가 조회할 수 있는 모든 PVC 중 'unused-delete-list : include' label 가지는 Unused PVC 삭제
      * @return ResponseResult
+     * @see #isUnusedPVC(List, PersistentVolumeClaim)
+     * @see #isDeleted(PersistentVolumeClaim)
      */
     public ResponseResult deleteUnusedPVC() {
 
         String result;
-        int count = 0;
         List<MountedPod> mountedPodList = findAllPVCMountedByPod().getPodSpecMountedVolume();
 
-        List<PersistentVolumeClaim> includedPVCList = client.persistentVolumeClaims().inAnyNamespace().withLabel("unused-delete-list", "include").list().getItems();
-        for (PersistentVolumeClaim includedPVC : includedPVCList) {
-            if(isUnusedPVC(mountedPodList, includedPVC)) {
-                String pvcName = includedPVC.getMetadata().getName();
-                String pvcNamespace = includedPVC.getMetadata().getNamespace();
-
-                if (client.persistentVolumeClaims().inNamespace(pvcNamespace).withName(pvcName).delete()) {
-                    count ++;
-                }
-            }
-        }
+        int count = (int) client.persistentVolumeClaims().inAnyNamespace().withLabel("unused-delete-list", "include").list().getItems()
+            .stream()
+            .filter(pvc -> isUnusedPVC(mountedPodList, pvc))
+            .filter(pvc -> isDeleted(pvc))
+            .count();
 
         if (count > 0) {
             result = count + " PVCs deleted";
@@ -1142,24 +1166,19 @@ public class UnusedResourceService {
      * 특정 namespace의 PVC 중 'unused-delete-list : include' label 가지는 Unused PVC 삭제
      * @param namespace namespace 지정
      * @return ResponseResult
+     * @see #isUnusedPVC(List, PersistentVolumeClaim)
+     * @see #isDeleted(PersistentVolumeClaim)
      */
     public ResponseResult deleteUnusedPVC(String namespace) {
 
         String result;
-        int count = 0;
         List<MountedPod> mountedPodList = findAllPVCMountedByPod().getPodSpecMountedVolume();
 
-        List<PersistentVolumeClaim> includedPVCList = client.persistentVolumeClaims().inNamespace(namespace).withLabel("unused-delete-list", "include").list().getItems();
-        for (PersistentVolumeClaim includedPVC : includedPVCList) {
-            if(isUnusedPVC(mountedPodList, includedPVC)) {
-                String pvcName = includedPVC.getMetadata().getName();
-                String pvcNamespace = includedPVC.getMetadata().getNamespace();
-
-                if (client.persistentVolumeClaims().inNamespace(pvcNamespace).withName(pvcName).delete()) {
-                    count ++;
-                }
-            }
-        }
+        int count = (int) client.persistentVolumeClaims().inNamespace(namespace).withLabel("unused-delete-list", "include").list().getItems()
+            .stream()
+            .filter(pvc -> isUnusedPVC(mountedPodList, pvc))
+            .filter(pvc -> isDeleted(pvc))
+            .count();
 
         if (count > 0) {
             result = count + " PVCs deleted";
@@ -1178,19 +1197,13 @@ public class UnusedResourceService {
     public ResponseResult deleteUnusedPV() {
 
         String result;
-        int count = 0;
         List<MountedPod> mountedPodList = findAllPVCMountedByPod().getPodSpecMountedVolume();
 
-        List<PersistentVolume> includedPVList = client.persistentVolumes().withLabel("unused-delete-list", "include").list().getItems();
-        for (PersistentVolume includedPV : includedPVList) {
-            if(isUnusedPV(mountedPodList, includedPV)) {
-                String pvName = includedPV.getMetadata().getName();
-
-                if (client.persistentVolumes().withName(pvName).delete()) {
-                    count ++;
-                }
-            }
-        }
+        int count = (int) client.persistentVolumes().withLabel("unused-delete-list", "include").list().getItems()
+            .stream()
+            .filter(pv -> isUnusedPV(mountedPodList, pv))
+            .filter(pv -> isDeleted(pv))
+            .count();
 
         if (count > 0) {
             result = count + " PVs deleted";

--- a/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
@@ -22,10 +22,10 @@ public class UnusedResourceService {
 
     private static KubernetesClient client = new DefaultKubernetesClient();
 
-    private static String apiurl = "api/v1/unused";
-    private static String apiurl_ns = "api/v1/unused/ns/";
-    private static String apiurl_pvcs = "api/v1/unused/pvcs";
-    private static String apiurl_pvs = "api/v1/unused/pvs";
+    private static final String apiurl = "api/v1/unused";
+    private static final String apiurl_ns = "api/v1/unused/ns/";
+    private static final String apiurl_pvcs = "api/v1/unused/pvcs";
+    private static final String apiurl_pvs = "api/v1/unused/pvs";
 
     public JSONObject setConfig(MultipartFile conf) throws IOException {
 
@@ -192,6 +192,11 @@ public class UnusedResourceService {
                             object.put("status", pvc.getStatus().getPhase());
                             object.put("boundedPV", pvc.getSpec().getVolumeName());
                             object.put("storageClassName", pvc.getSpec().getStorageClassName());
+                            if (pvc.getMetadata().getLabels() != null) {
+                                object.put("label/unused-delete-list", pvc.getMetadata().getLabels().get("unused-delete-list"));
+                            } else {
+                                object.put("label/unused-delete-list", null);
+                            }
                             object.put("unusedType", checkUnusedPVCType(mountedByPods, pvc));
                             pvc_object_list.add(object);
                         }
@@ -227,6 +232,11 @@ public class UnusedResourceService {
                             object.put("volumeReclaimPolicy", pv.getSpec().getPersistentVolumeReclaimPolicy());
                             object.put("storageClassName", pv.getSpec().getStorageClassName());
                             object.put("unusedType", checkUnusedPVType(mountedByPods, pv));
+                            if (pv.getMetadata().getLabels() != null) {
+                                object.put("label/unused-delete-list", pv.getMetadata().getLabels().get("unused-delete-list"));
+                            } else {
+                                object.put("label/unused-delete-list", null);
+                            }
                             if (pv.getSpec().getClaimRef() != null) {
                                 object.put("boundedPVC", pv.getSpec().getClaimRef().getName());
                             }

--- a/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
@@ -1,0 +1,376 @@
+package com.cloudzcp.kuberest.api.core.service;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Service;
+
+import io.fabric8.kubernetes.api.model.PersistentVolume;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
+import io.fabric8.kubernetes.api.model.PersistentVolumeList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@Service
+public class UnusedResourceService {
+
+    private JSONArray mountedByPods = findAllPVCMountedByPod();
+    private static KubernetesClient client = new DefaultKubernetesClient();
+    private static FileWriter file;
+    private static PersistentVolumeClaimList pvc_list;
+    private static PersistentVolumeList pv_list;
+    private static JSONObject data;
+    private static JSONObject response;
+
+    public JSONObject countAll(String namespace){
+
+        JSONObject pvc_object_count = new JSONObject();
+        JSONObject pv_object_count = new JSONObject();
+        JSONObject pvc_object = new JSONObject();
+        JSONObject pv_object = new JSONObject();
+        data = new JSONObject();
+        response = new JSONObject();
+
+        if (namespace != null) {
+            pvc_list = client.persistentVolumeClaims().inNamespace(namespace).list();
+            data.put("selfLink", "api/v1/unused/ns/"+namespace+"/count");
+        } else {
+            pvc_list = client.persistentVolumeClaims().inAnyNamespace().list();
+            pv_list = client.persistentVolumes().list();
+            data.put("selfLink", "api/v1/unused/count");
+
+            pv_object_count.put("total", pv_list.getItems().size());
+            pv_object_count.put("unused", pv_list.getItems().stream().filter(pv -> isUnused(pv, null)).count());
+            pv_object.put("count", pv_object_count);
+            data.put("PV", pv_object);
+        }
+
+        pvc_object_count.put("total", pvc_list.getItems().size());
+        pvc_object_count.put("unused", pvc_list.getItems().stream().filter(pvc -> isUnused(null, pvc)).count());
+        pvc_object.put("count", pvc_object_count);
+        data.put("PVC", pvc_object);
+        response.put("data", data);
+        return response;
+    }
+
+    public JSONObject findAll(String namespace){
+
+        JSONObject pvc_object_count = new JSONObject();
+        JSONArray pvc_object_list = new JSONArray();
+        JSONObject pvc_object = new JSONObject();
+        JSONObject pv_object_count = new JSONObject();
+        JSONArray pv_object_list = new JSONArray();
+        JSONObject pv_object = new JSONObject();
+        data = new JSONObject();
+        response = new JSONObject();
+
+        if (namespace != null) {
+            pvc_list = client.persistentVolumeClaims().inNamespace(namespace).list();
+            data.put("selfLink", "api/v1/unused/ns/"+namespace);
+        } else {
+            pvc_list = client.persistentVolumeClaims().inAnyNamespace().list();
+            pv_list = client.persistentVolumes().list();
+            data.put("selfLink", "api/v1/unused");
+
+            pv_list.getItems().forEach(
+                pv -> {
+                    if(isUnused(pv, null)){
+                        JSONObject object = new JSONObject();
+                        object.put("name", pv.getMetadata().getName());
+                        object.put("status", pv.getStatus().getPhase());
+                        object.put("volumeReclaimPolicy", pv.getSpec().getPersistentVolumeReclaimPolicy());
+                        object.put("storageClassName", pv.getSpec().getStorageClassName());
+                        object.put("unusedType", checkUnusedType(pv, null));
+                        pv_object_list.add(object);
+                    }
+                }
+            );
+            pv_object_count.put("total", pv_list.getItems().size());
+            pv_object_count.put("unused", pv_list.getItems().stream().filter(pv -> isUnused(pv, null)).count());
+            pv_object.put("count", pv_object_count);
+            pv_object.put("unusedList", pv_object_list);
+
+            data.put("PV", pv_object);
+        }
+
+        pvc_list.getItems().forEach(
+            pvc -> {
+                if(isUnused(null, pvc)){
+                    JSONObject object = new JSONObject();
+                    object.put("name", pvc.getMetadata().getName());
+                    object.put("namespace", pvc.getMetadata().getNamespace());
+                    object.put("status", pvc.getStatus().getPhase());
+                    object.put("volume", pvc.getSpec().getVolumeName());
+                    object.put("storageClassName", pvc.getSpec().getStorageClassName());
+                    object.put("unusedType", checkUnusedType(null, pvc));
+                    pvc_object_list.add(object);
+                }
+            }
+        );
+        pvc_object_count.put("total", pvc_list.getItems().size());
+        pvc_object_count.put("unused", pvc_list.getItems().stream().filter(pvc -> isUnused(null, pvc)).count());
+        pvc_object.put("count", pvc_object_count);
+        pvc_object.put("unusedList", pvc_object_list);
+
+        data.put("PVC", pvc_object);
+        response.put("data", data);
+
+        return response;
+    }
+
+    public JSONObject findPVC(String namespace){
+
+        JSONArray pvc_object_list = new JSONArray();
+        JSONObject pvc_object = new JSONObject();
+        data = new JSONObject();
+        response = new JSONObject();
+
+        if (namespace != null) {
+            pvc_list = client.persistentVolumeClaims().inNamespace(namespace).list();
+            data.put("selfLink", "api/v1/unused/ns/"+namespace+"/pvcs");
+            
+        } else {
+            pvc_list = client.persistentVolumeClaims().inAnyNamespace().list();
+            data.put("selfLink", "api/v1/unused/pvcs");
+        }
+
+        pvc_list.getItems().forEach(
+            pvc -> {
+                if(isUnused(null, pvc)){
+                    JSONObject object = new JSONObject();
+                    object.put("name", pvc.getMetadata().getName());
+                    object.put("namespace", pvc.getMetadata().getNamespace());
+                    object.put("status", pvc.getStatus().getPhase());
+                    object.put("boundedPV", pvc.getSpec().getVolumeName());
+                    object.put("storageClassName", pvc.getSpec().getStorageClassName());
+                    object.put("unusedType", checkUnusedType(null, pvc));
+                    pvc_object_list.add(object);
+                }
+            }
+        );
+
+        pvc_object.put("unusedList", pvc_object_list);
+        data.put("PVC", pvc_object);
+        response.put("data", data);
+        return response;
+    }
+
+    public JSONObject findPVC(String namespace, String name){
+
+        JSONObject pvc_object = new JSONObject();
+        data = new JSONObject();
+        response = new JSONObject();
+
+        PersistentVolumeClaim pvc = client.persistentVolumeClaims().inNamespace(namespace).withName(name).get();
+
+        if (pvc == null) {
+
+        } else if (!isUnused(null,pvc)) {
+            data.put("unusedType", name+" is used resource");
+        } else {
+            JSONObject object = new JSONObject();
+            object.put("unusedType", checkUnusedType(null, pvc));
+            object.put("detail", pvc);
+            pvc_object.put(name, object);
+            data.put("PVC", pvc_object);
+        }
+
+        data.put("selfLink", "api/v1/unused/ns/"+namespace+"/pvcs/"+name);
+        response.put("data", data);
+        return response;
+    }
+
+    public JSONObject findPV(){
+        
+        JSONArray pv_object_list = new JSONArray();
+        JSONObject pv_object = new JSONObject();
+        data = new JSONObject();
+        response = new JSONObject();
+
+        data.put("selfLink", "api/v1/unused/pvs");
+        client.persistentVolumes().list().getItems().forEach(
+            pv -> {
+                if(isUnused(pv, null)){
+                    JSONObject object = new JSONObject();
+                    object.put("name", pv.getMetadata().getName());
+                    object.put("status", pv.getStatus().getPhase());
+                    object.put("volumeReclaimPolicy", pv.getSpec().getPersistentVolumeReclaimPolicy());
+                    object.put("storageClassName", pv.getSpec().getStorageClassName());
+                    object.put("unusedType", checkUnusedType(pv, null));
+                    if (pv.getSpec().getClaimRef() != null) {
+                        object.put("boundedPVC", pv.getSpec().getClaimRef().getName());
+                    }
+                    pv_object_list.add(object);
+                }
+            }
+        );
+
+        pv_object.put("unusedList", pv_object_list);
+        data.put("PV", pv_object);
+        response.put("data", data);
+        return response;
+    }
+
+    public JSONObject findPV(String name){
+        
+        JSONObject pv_object = new JSONObject();
+        data = new JSONObject();
+        response = new JSONObject();
+
+        PersistentVolume pv = client.persistentVolumes().withName(name).get();
+
+        if (pv == null) {
+
+        } else if (!isUnused(pv, null)) {
+            data.put("unusedType", name+" is used resource");
+        } else {
+            JSONObject object = new JSONObject();
+            object.put("unusedType", checkUnusedType(pv, null));
+            object.put("detail", pv);
+            pv_object.put(name, object);
+            data.put("PVC", pv_object);
+        }
+
+        data.put("selfLink", "api/v1/unused/pvs/"+name);
+        response.put("data", data);
+        return response;
+    }
+
+    public JSONArray findAllPVCMountedByPod(){
+
+        JSONArray pod_object_list = new JSONArray();
+
+        client.pods().inAnyNamespace().list().getItems().forEach(
+            pod -> {
+                JSONObject object = new JSONObject();
+                JSONArray object_list = new JSONArray();
+                object.put("name", pod.getMetadata().getName());
+                object.put("namespace", pod.getMetadata().getNamespace());
+
+                pod.getSpec().getVolumes().forEach(
+                    volume -> {
+                        if (volume.getPersistentVolumeClaim() != null){
+                            JSONObject pvc_temp = new JSONObject();
+                            String claimName = volume.getPersistentVolumeClaim().getClaimName();
+                            pvc_temp.put("claimName", claimName);
+                            pvc_temp.put("boundedPV", client.persistentVolumeClaims().inNamespace(pod.getMetadata().getNamespace()).withName(claimName).get().getSpec().getVolumeName());
+                            object_list.add(pvc_temp);
+                        }
+                        
+                    }
+                );
+
+                if (object_list.size() > 0) {
+                    object.put("pvcs", object_list);
+                    pod_object_list.add(object);
+                }
+            }
+        );
+
+        return pod_object_list;
+    }
+
+    public JSONObject printPVCMountedByPod(){
+        data = new JSONObject();
+        response = new JSONObject();
+
+        data.put("PodSpecMountVolume", mountedByPods);
+        response.put("data", data);
+
+        return response;
+    }
+
+    public Boolean isMountedByPod(String claimName, String namespace){
+        Boolean result = false;
+
+        if (!mountedByPods.isEmpty()) {
+            for (int i=0; i<mountedByPods.size(); i++){
+                JSONObject pod = (JSONObject)mountedByPods.get(i);
+                JSONArray pvcs = (JSONArray)pod.get("pvcs");
+                for (int j=0; j<pvcs.size(); j++) {
+                    if (((JSONObject)pvcs.get(j)).get("claimName").toString().equals(claimName) && pod.get("namespace").toString().equals(namespace)){
+                        result = true;
+                        return result;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public Boolean isUnused(PersistentVolume pv, PersistentVolumeClaim pvc) {
+        Boolean result = false;
+        if (pv != null) {
+            if (pv.getStatus().getPhase().equals("Terminating")) {
+                return false;
+            }
+            if (!pv.getStatus().getPhase().equals("Bound")) {
+                return true;
+            }
+            if (pv.getSpec().getClaimRef() != null){
+                if (!isMountedByPod(pv.getSpec().getClaimRef().getName(), pv.getSpec().getClaimRef().getNamespace())) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        } else if (pvc != null) {
+            if (pvc.getStatus().getPhase().equals("Terminating")){
+                return false;
+            }
+            if (!isMountedByPod(pvc.getMetadata().getName(), pvc.getMetadata().getNamespace())){
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        return result;
+    }
+
+    public String checkUnusedType(PersistentVolume pv, PersistentVolumeClaim pvc) {
+        String result = "";
+        if (pv != null) {
+            if (!pv.getStatus().getPhase().equals("Bound")) {
+                return "PV Status is not 'Bound'";
+            }
+            if (pv.getSpec().getClaimRef() != null){
+                if (!isMountedByPod(pv.getSpec().getClaimRef().getName(), pv.getSpec().getClaimRef().getNamespace())) {
+                    result = "PVC("+pv.getSpec().getClaimRef().getName()+") connected to PV is not mounted by Pod";
+                }
+            }
+        } else if (pvc != null) {
+            if (!isMountedByPod(pvc.getMetadata().getName(), pvc.getMetadata().getNamespace())){
+                if (!pvc.getStatus().getPhase().equals("Bound")) {
+                    result = "PVC is not mounted by Pod / PVC Status is not 'Bound'";
+                } else {
+                    result = "PVC is not mounted by Pod";
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public void createJSONFile(JSONObject obj, String filename){
+        String home = System.getProperty("user.home");
+        try {
+            file = new FileWriter(home + "/Downloads/" + filename + ".json");
+            file.write(obj.toJSONString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                file.flush();
+                file.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        
+    }
+}

--- a/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
+++ b/src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java
@@ -1,6 +1,5 @@
 package com.cloudzcp.kuberest.api.core.service;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -27,6 +26,7 @@ public class UnusedResourceService {
     private static final String apiurl_pvcs = "api/v1/unused/pvcs";
     private static final String apiurl_pvs = "api/v1/unused/pvs";
 
+    //thread safe 문제 해결 필요
     public JSONObject setConfig(MultipartFile conf) throws IOException {
 
         JSONObject data = new JSONObject();
@@ -359,7 +359,7 @@ public class UnusedResourceService {
         JSONArray mountedByPods = findAllPVCMountedByPod();
 
         if (pvc == null) {
-
+            data.put("result", name+" not found");
         } else if (!isUnusedPVC(mountedByPods, pvc)) {
             data.put("unusedType", name+" is used resource");
         } else {
@@ -406,7 +406,7 @@ public class UnusedResourceService {
         JSONArray mountedByPods = findAllPVCMountedByPod();
 
         if (pv == null) {
-
+            data.put("result", name+" not found");
         } else if (!isUnusedPV(mountedByPods, pv)) {
             data.put("unusedType", name+" is used resource");
         } else {
@@ -420,22 +420,6 @@ public class UnusedResourceService {
         data.put("selfLink", apiurl_pvs+name);
         response.put("data", data);
         return response;
-    }
-
-    public void createJSONFile(JSONObject obj, String filename){
-
-        String home = System.getProperty("user.home");
-        FileWriter file;
-
-        try {
-            file = new FileWriter(home + "/Downloads/" + filename + ".json");
-            file.write(obj.toJSONString());
-            file.flush();
-            file.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        
     }
 
     public JSONObject deleteUnusedPVC(String namespace, String pvc_name) {

--- a/src/main/java/com/cloudzcp/kuberest/config/SwaggerConfig.java
+++ b/src/main/java/com/cloudzcp/kuberest/config/SwaggerConfig.java
@@ -26,6 +26,6 @@ public class SwaggerConfig {
     }
     
     private ApiInfo apiInfo() {
-        return new ApiInfoBuilder().title("Kuberest API").description("Kuberest API Example").build();
+        return new ApiInfoBuilder().title("Kuberest API").description("Unused Kuberest Resource(PV, PVC)를 조회 및 삭제하는 API").build();
     }
 }


### PR DESCRIPTION
### REST API로 Unused Kubernetes Resource (PV, PVC)를 삭제
**src/main/java/com/cloudzcp/kuberest/api/core/service/UnusedResourceService.java**

[삭제 Process]

- 단일 resource는 resource name, namespace 지정해서 완전 삭제
    - deleteUnusedPVC(), deleteUnusedPV()

- 다중 resource는 아래의 프로세스에 따라 검증 후 삭제

    1. 특정 resource에 삭제 방지 - 삭제 방지는 resource에 label 추가하여 관리

    2. 미사용 resource 목록을 삭제 대상으로 지정 - 삭제 대상은 resource에 label 추가하여 관리. 삭제 방지 resource는 제외
        - putLabelOnUnusedAll(), putLabelOnUnusedPVCList(), putLabelOnUnusedPVCListInNamespace(), putLabelOnUnusedPVList(), putLabelOnUnusedPVC(), putLabelOnUnusedPV()
        - (unused) PVC/PV 전체, PVC 전체, PV 전체, 특정 PVC, 특정 PV에 "unused-delete-list"를 key로 갖는 label을 부착하여 관리
        - exclude(삭제 방지 대상), include(삭제 대상), release(삭제/삭제 방지 대상에서 제외) 세 가지 type 중 하나를 지정하여 api 요청
        - 특정 조건에 해당하는 PV, PVC에 label 부착 가능
            - 조건 : namespace, storageclassname, status, label

    3. [사용자 검증] 삭제 대상 조회
        - unused resource 조회 api에 parameter "deleteList" 추가
            - include (삭제 대상 조회)
            - exclude (삭제 방지 대상 조회)

    4. 실제 삭제
        - deleteUnusedAll(), deleteUnusedPVCList(), deleteUnusedPVCListInNamespace(), deleteUnusedPVList()
        - "unused-delete-list=include" label이 있는 unused PVC/PV를 삭제
        - param "script=true"로 수행 시 실제 삭제를 수행하지 않고 삭제할 수 있는 kubectl 커맨드를 출력